### PR TITLE
Implement IEquatable<T> in GeoCoordinate and Distance

### DIFF
--- a/src/AM.Common.GeoLocation/Distance.cs
+++ b/src/AM.Common.GeoLocation/Distance.cs
@@ -5,7 +5,7 @@ namespace AM.Common.GeoLocation
     /// <summary>
     /// Represents distance in unit-agnostic way.
     /// </summary>
-    public struct Distance
+    public struct Distance : IEquatable<Distance>
     {
         private readonly GeoDistanceUnit unitOfLength;
         private readonly double value;

--- a/src/AM.Common.GeoLocation/GeoCoordinate.cs
+++ b/src/AM.Common.GeoLocation/GeoCoordinate.cs
@@ -5,7 +5,7 @@ namespace AM.Common.GeoLocation
     /// <summary>
     /// Represents a geo location coordinate.
     /// </summary>
-    public struct GeoCoordinate
+    public struct GeoCoordinate : IEquatable<GeoCoordinate>
     {
         /// <summary>
         /// Gets or sets the Latitude value of the coordinate.


### PR DESCRIPTION
This allows collections like `System.Collections.Generic.Dictionary<,>` to use the `Equals()` overload that doesn't box the struct.